### PR TITLE
preallocate the `results` Array

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
 'use strict'
 
 module.exports = function mapTimes (count, callback) {
-  var results = []
+  var results = new Array(count)
   for (var i = 0; i < count; i++) {
-    results.push(callback(i))
+    results[i] = callback(i)
   }
   return results
 }


### PR DESCRIPTION
Micro-optimization: since we know the size of the `results` array up-front, preallocate the Array with the proper `.length`.
